### PR TITLE
Support for 160x80 0.96" LCD Breakout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Python ST7735
-=======================
+Python ST7735 160x80
+====================
 
 Python library to control an ST7735 TFT LCD display.  Allows simple drawing on the display without installing a kernel module.
 
-Designed specifically to work with a ST7735 based 128x160 pixel TFT SPI display.
+Designed specifically to work with a ST7735 based 160x80 pixel TFT SPI display. (Specifically the 0.96" SPI LCD from Pimoroni).
 
 For all platforms (Raspberry Pi and Beaglebone Black) make sure you have the following dependencies:
 
@@ -33,8 +33,10 @@ sudo python setup.py install
 
 See example of usage in the examples folder.
 
+Pimoroni invests time and resources forking and slightly modifying this open source code, please support Pimoroni and open-source software by purchasing products from us, too!
+
 Adafruit invests time and resources providing this open source code, please support Adafruit and open-source hardware by purchasing products from Adafruit!
 
-Modified from 'Adafruit Python ILI9341' written by Tony DiCola for Adafruit Industries.
+Modified from 'Modified from 'Adafruit Python ILI9341' written by Tony DiCola for Adafruit Industries.' written by Clement Skau.
 
 MIT license, all text above must be included in any redistribution

--- a/examples/gif.py
+++ b/examples/gif.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2014 Adafruit Industries
+# Author: Phil Howard, Tony DiCola
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+from PIL import Image
+import ST7735 as TFT
+import Adafruit_GPIO.SPI as SPI
+import time
+import sys
+
+image_file = sys.argv[1]
+
+WIDTH = TFT.ST7735_TFTWIDTH
+HEIGHT = TFT.ST7735_TFTHEIGHT
+SPEED_HZ = 4000000
+
+# Raspberry Pi configuration.
+DC = 5
+RST = 25
+SPI_PORT = 0
+SPI_DEVICE = 0
+
+# Create TFT LCD display class.
+disp = TFT.ST7735(
+    DC,
+    rst=RST,
+    spi=SPI.SpiDev(
+        SPI_PORT,
+        SPI_DEVICE,
+        max_speed_hz=SPEED_HZ))
+
+# Initialize display.
+disp.begin()
+
+# Load an image.
+print('Loading gif: {}...'.format(image_file))
+image = Image.open(image_file)
+
+print('Drawing gif')
+
+frame = 0
+
+while True:
+    try:
+        image.seek(frame)
+        disp.display(image.resize((WIDTH, HEIGHT)))
+        frame += 1
+        time.sleep(0.05)
+    except EOFError:
+        frame = 0
+    

--- a/examples/image.py
+++ b/examples/image.py
@@ -21,18 +21,24 @@
 from PIL import Image
 
 import ST7735 as TFT
-import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
+import time
 
+import sys
 
-WIDTH = 128
-HEIGHT = 160
+if len(sys.argv) < 2:
+    print("Usage: {} <image_file>".format(sys.argv[0]))
+    sys.exit(1)
+
+image_file = sys.argv[1]
+
+WIDTH = TFT.ST7735_TFTWIDTH
+HEIGHT = TFT.ST7735_TFTHEIGHT
 SPEED_HZ = 4000000
 
 
 # Raspberry Pi configuration.
-DC = 24
-RST = 25
+DC = 5
 SPI_PORT = 0
 SPI_DEVICE = 0
 
@@ -45,7 +51,6 @@ SPI_DEVICE = 0
 # Create TFT LCD display class.
 disp = TFT.ST7735(
     DC,
-    rst=RST,
     spi=SPI.SpiDev(
         SPI_PORT,
         SPI_DEVICE,
@@ -55,12 +60,14 @@ disp = TFT.ST7735(
 disp.begin()
 
 # Load an image.
-print('Loading image...')
-image = Image.open('cat.jpg')
+print('Loading image: {}...'.format(image_file))
+image = Image.open(image_file)
 
 # Resize the image and rotate it so matches the display.
-image = image.rotate(90).resize((WIDTH, HEIGHT))
+# image = image.rotate(90).resize((WIDTH, HEIGHT))
+image = image.resize((WIDTH, HEIGHT))
 
 # Draw the image on the display hardware.
 print('Drawing image')
+
 disp.display(image)

--- a/examples/image_timed.py
+++ b/examples/image_timed.py
@@ -24,14 +24,23 @@ import ST7735 as TFT
 import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
 
+import sys
 
-WIDTH = 128
-HEIGHT = 160
-SPEED_HZ = 4000000
+if len(sys.argv) < 2:
+    print("Usage: {} <image_file>".format(sys.argv[0]))
+    sys.exit(1)
+
+image_file = sys.argv[1]
+
+
+
+WIDTH = 160
+HEIGHT = 80
+SPEED_HZ = 16000000
 
 
 # Raspberry Pi configuration.
-DC = 24
+DC = 5
 RST = 25
 SPI_PORT = 0
 SPI_DEVICE = 0
@@ -56,10 +65,10 @@ disp.begin()
 
 # Load an image.
 print('Loading image...')
-image = Image.open('cat.jpg')
+image = Image.open(image_file)
 
 # Resize the image and rotate it so matches the display.
-image = image.rotate(90).resize((WIDTH, HEIGHT))
+image = image.rotate(0).resize((WIDTH, HEIGHT))
 
 print('Press Ctrl-C to exit')
 while(True):
@@ -69,5 +78,5 @@ while(True):
     disp.display(image)
     end_time = time.time()
     print('Time to draw image: ' + str(end_time - start_time))
-    disp.clear((0, 0, 0))
-    disp.display()
+    # disp.clear((0, 0, 0))
+    # disp.display()

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -23,18 +23,16 @@ from PIL import ImageDraw
 from PIL import ImageFont
 
 import ST7735 as TFT
-import Adafruit_GPIO as GPIO
 import Adafruit_GPIO.SPI as SPI
 
 
-WIDTH = 128
-HEIGHT = 160
+WIDTH = 160
+HEIGHT = 80
 SPEED_HZ = 4000000
 
 
 # Raspberry Pi configuration.
-DC = 24
-RST = 25
+DC = 5
 SPI_PORT = 0
 SPI_DEVICE = 0
 
@@ -47,7 +45,6 @@ SPI_DEVICE = 0
 # Create TFT LCD display class.
 disp = TFT.ST7735(
     DC,
-    rst=RST,
     spi=SPI.SpiDev(
         SPI_PORT,
         SPI_DEVICE,
@@ -66,19 +63,19 @@ disp.clear((255, 0, 0))
 # Get a PIL Draw object to start drawing on the display buffer.
 draw = disp.draw()
 
+# Draw a purple rectangle with yellow outline.
+draw.rectangle((10, 10, WIDTH-10, HEIGHT-10), outline=(255,255,0), fill=(255,0,255))
+
 # Draw some shapes.
 # Draw a blue ellipse with a green outline.
-draw.ellipse((10, 10, 110, 80), outline=(0,255,0), fill=(0,0,255))
-
-# Draw a purple rectangle with yellow outline.
-draw.rectangle((10, 90, 110, 160), outline=(255,255,0), fill=(255,0,255))
+draw.ellipse((10, 10, WIDTH-10, HEIGHT-10), outline=(0,255,0), fill=(0,0,255))
 
 # Draw a white X.
-draw.line((10, 170, 110, 230), fill=(255,255,255))
-draw.line((10, 230, 110, 170), fill=(255,255,255))
+draw.line((10, 10, WIDTH-10, HEIGHT-10), fill=(255,255,255))
+draw.line((10, HEIGHT-10, WIDTH-10, 10), fill=(255,255,255))
 
 # Draw a cyan triangle with a black outline.
-draw.polygon([(10, 275), (110, 240), (110, 310)], outline=(0,0,0), fill=(0,255,255))
+draw.polygon([(WIDTH/2, 10), (WIDTH-10, HEIGHT-10), (10, HEIGHT-10)], outline=(0,0,0), fill=(0,255,255))
 
 # Load default font.
 font = ImageFont.load_default()
@@ -105,8 +102,8 @@ def draw_rotated_text(image, text, position, angle, font, fill=(255,255,255)):
     image.paste(rotated, position, rotated)
 
 # Write two lines of white text on the buffer, rotated 90 degrees counter clockwise.
-draw_rotated_text(disp.buffer, 'Hello World!', (150, 120), 90, font, fill=(255,255,255))
-draw_rotated_text(disp.buffer, 'This is a line of text.', (170, 90), 90, font, fill=(255,255,255))
+draw_rotated_text(disp.buffer, 'Hello World!', (0, 0), 90, font, fill=(255,255,255))
+draw_rotated_text(disp.buffer, 'This is a line of text.', (10, HEIGHT-10), 0, font, fill=(255,255,255))
 
 # Write buffer to display hardware, must be called to make things visible on the
 # display!


### PR DESCRIPTION
This set of changes modifies this library to support the 160x80 0.96" LCD breakout.

This breakout works in portrait mode, so some X/Y coordinates are swapped, and is center-aligned within the memory buffer.

It's also inversed, for reasons!